### PR TITLE
Fix: Add MINECRAFT Pricing information

### DIFF
--- a/src/token-list.json
+++ b/src/token-list.json
@@ -793,5 +793,25 @@
     "extensions": {
       "coingeckoId": "kineko"
     }
-  }
+  },
+   {
+      "chainId": 101,
+      "address": "FTkj421DxbS1wajE74J34BJ5a1o9ccA97PkK6mYq9hNQ",
+      "symbol": "MINECRAFT",
+      "name": "Synex Coin",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/FTkj421DxbS1wajE74J34BJ5a1o9ccA97PkK6mYq9hNQ/logo.png",
+      "tags": [
+        "utility-token",
+        "community-token"
+      ],
+      "extensions": {
+        "coingeckoId": "synex-coin",
+        "coinmarketcap": "https://coinmarketcap.com/currencies/synex-coin/",
+        "serumV3Usdc": "HYH4sxk2pCZMJV7pSzg1davjfJbSTVzg5onJUMAMo83r",
+        "discord": "https://discord.gg/N3BE44234A",
+        "telegram": "https://t.me/synexcoin",
+        "website": "https://synexcoin.dev"
+      }
+    }
 ]

--- a/src/token-list.json
+++ b/src/token-list.json
@@ -806,7 +806,7 @@
       "community-token"
     ],
     "extensions": {
-      "coingeckoId": "synex-coin",
+      "coingeckoId": "synex-coin"
     }
   },
   {


### PR DESCRIPTION
Intent:
- At least one user is having trouble interacting with a MINECRAFT/STEP farm due to no pricing information available
- MINECRAFT token has an open PR adding coingecko and serum fields here:
    - `Add Cmc and Coingecko as well as Serum mkt id for Synex Coin (MINECRAFT)` https://github.com/solana-labs/token-list/pull/6510/files
- I ported over this code. This is my first contribution to `token-list-overrides` so please review carefully. I believe updates from here get pulled in every 3 hours