### PR TITLE
SF-1093: Add new version ctokens

### DIFF
--- a/src/token-list.json
+++ b/src/token-list.json
@@ -1499,7 +1499,7 @@
       "solend",
       "lending",
       "collateral-tokens"
-    ],,
+    ],
     "extensions": {
       "coingeckoId": "ethereum"
     }
@@ -1611,7 +1611,7 @@
       "solend",
       "lending",
       "collateral-tokens"
-    ],,
+    ],
     "extensions": {
       "coingeckoId": "ftx-token"
     }

--- a/src/token-list.json
+++ b/src/token-list.json
@@ -1603,11 +1603,7 @@
     "name": "Solend FTT",
     "decimals": 8,
     "logoURI": "https://solend.fi/assets/ctokens/cftt.svg",
-    "tags": [
-      "solend",
-      "lending",
-      "collateral-tokens"
-    ],
+    "tags": ["solend"],
     "extensions": {
       "coingeckoId": "ftx-token"
     }

--- a/src/token-list.json
+++ b/src/token-list.json
@@ -1490,22 +1490,6 @@
   },
   {
     "chainId": 101,
-    "address": "FbKvdbx5h6F86h1pZuEqv7FxwmsVhJ88cDuSqHvLm6Xf",
-    "symbol": "cETH",
-    "name": "Solend ETH",
-    "decimals": 8,
-    "logoURI": "https://solend.fi/assets/ctokens/ceth.svg",
-    "tags": [
-      "solend",
-      "lending",
-      "collateral-tokens"
-    ],
-    "extensions": {
-      "coingeckoId": "ethereum"
-    }
-  },
-  {
-    "chainId": 101,
     "address": "AppJPZka33cu4DyUenFe9Dc1ZmZ3oQju6mBn9k37bNAa",
     "symbol": "csoETH",
     "name": "Solend soETH",
@@ -1591,22 +1575,6 @@
     "name": "Solend FTT",
     "decimals": 6,
     "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/8bDyV3N7ctLKoaSVqUoEwUzw6msS2F65yyNPgAVUisKm/logo.png",
-    "tags": [
-      "solend",
-      "lending",
-      "collateral-tokens"
-    ],
-    "extensions": {
-      "coingeckoId": "ftx-token"
-    }
-  },
-  {
-    "chainId": 101,
-    "address": "DiMx1n2dJmxqFtENRPhYWsqi8Mhg2p39MpTzsm6phzMP",
-    "symbol": "cFTT",
-    "name": "Solend FTT",
-    "decimals": 8,
-    "logoURI": "https://solend.fi/assets/ctokens/cftt.svg",
     "tags": [
       "solend",
       "lending",
@@ -1962,6 +1930,91 @@
     "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/CH74tuRLTYcxG7qNJCsV9rghfLXJCQJbsu7i52a8F1Gn/logo.png",
     "extensions": {
       "coingeckoId": "soldex"
+    }
+  },
+  {
+    "chainId": 101,
+    "address": "FbKvdbx5h6F86h1pZuEqv7FxwmsVhJ88cDuSqHvLm6Xf",
+    "symbol": "cETH",
+    "name": "Solend ETH",
+    "decimals": 8,
+    "logoURI": "https://solend.fi/assets/ctokens/ceth.svg",
+    "tags": [
+      "solend",
+      "lending",
+      "collateral-tokens"
+    ],
+    "extensions": {
+      "website": "https://solend.fi",
+      "coingeckoId": "ethereum"
+    }
+  },
+  {
+    "chainId": 101,
+    "address": "DiMx1n2dJmxqFtENRPhYWsqi8Mhg2p39MpTzsm6phzMP",
+    "symbol": "cFTT",
+    "name": "Solend FTT",
+    "decimals": 8,
+    "logoURI": "https://solend.fi/assets/ctokens/cftt.svg",
+    "tags": [
+      "solend",
+      "lending",
+      "collateral-tokens"
+    ],
+    "extensions": {
+      "website": "https://solend.fi",
+      "coingeckoId": "ftx-token"
+    }
+  },
+  {
+    "chainId": 101,
+    "address": "D3Cu5urZJhkKyNZQQq2ne6xSfzbXLU4RrywVErMA2vf8",
+    "symbol": "cSLND",
+    "name": "Solend SLND",
+    "decimals": 6,
+    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/D3Cu5urZJhkKyNZQQq2ne6xSfzbXLU4RrywVErMA2vf8/logo.png",
+    "tags": [
+      "solend",
+      "lending",
+      "collateral-tokens"
+    ],
+    "extensions": {
+      "website": "https://solend.fi",
+      "coingeckoId": "solend"
+    }
+  },
+  {
+    "chainId": 101,
+    "address": "QQ6WK86aUCBvNPkGeYBKikk15sUg6aMUEi5PTL6eB4i",
+    "symbol": "cstSOL",
+    "name": "Lido Staked SOL",
+    "decimals": 9,
+    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/QQ6WK86aUCBvNPkGeYBKikk15sUg6aMUEi5PTL6eB4i/logo.png",
+    "tags": [
+      "solend",
+      "lending",
+      "collateral-tokens"
+    ],
+    "extensions": {
+      "website": "https://solend.fi",
+      "coingeckoId": "lido-staked-sol"
+    }
+  },
+  {
+    "chainId": 101,
+    "address": "AFq1sSdevxfqWGcmcz7XpPbfjHevcJY7baZf9RkyrzoR",
+    "symbol": "cscnSOL",
+    "name": "Socean Staked Sol",
+    "decimals": 9,
+    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/AFq1sSdevxfqWGcmcz7XpPbfjHevcJY7baZf9RkyrzoR/logo.png",
+    "tags": [
+      "solend",
+      "lending",
+      "collateral-tokens"
+    ],
+    "extensions": {
+      "website": "https://solend.fi",
+      "coingeckoId": "socean-staked-sol"
     }
   }
 ]

--- a/src/token-list.json
+++ b/src/token-list.json
@@ -1490,6 +1490,18 @@
   },
   {
     "chainId": 101,
+    "address": "FbKvdbx5h6F86h1pZuEqv7FxwmsVhJ88cDuSqHvLm6Xf",
+    "symbol": "cETH",
+    "name": "Solend ETH",
+    "decimals": 8,
+    "logoURI": "https://solend.fi/assets/ctokens/ceth.svg",
+    "tags": ["solend"],
+    "extensions": {
+      "coingeckoId": "ethereum"
+    }
+  },
+  {
+    "chainId": 101,
     "address": "AppJPZka33cu4DyUenFe9Dc1ZmZ3oQju6mBn9k37bNAa",
     "symbol": "csoETH",
     "name": "Solend soETH",
@@ -1575,6 +1587,22 @@
     "name": "Solend FTT",
     "decimals": 6,
     "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/8bDyV3N7ctLKoaSVqUoEwUzw6msS2F65yyNPgAVUisKm/logo.png",
+    "tags": [
+      "solend",
+      "lending",
+      "collateral-tokens"
+    ],
+    "extensions": {
+      "coingeckoId": "ftx-token"
+    }
+  },
+  {
+    "chainId": 101,
+    "address": "DiMx1n2dJmxqFtENRPhYWsqi8Mhg2p39MpTzsm6phzMP",
+    "symbol": "cFTT",
+    "name": "Solend FTT",
+    "decimals": 8,
+    "logoURI": "https://solend.fi/assets/ctokens/cftt.svg",
     "tags": [
       "solend",
       "lending",

--- a/src/token-list.json
+++ b/src/token-list.json
@@ -1495,7 +1495,11 @@
     "name": "Solend ETH",
     "decimals": 8,
     "logoURI": "https://solend.fi/assets/ctokens/ceth.svg",
-    "tags": ["solend"],
+    "tags": [
+      "solend",
+      "lending",
+      "collateral-tokens"
+    ],,
     "extensions": {
       "coingeckoId": "ethereum"
     }
@@ -1603,7 +1607,11 @@
     "name": "Solend FTT",
     "decimals": 8,
     "logoURI": "https://solend.fi/assets/ctokens/cftt.svg",
-    "tags": ["solend"],
+    "tags": [
+      "solend",
+      "lending",
+      "collateral-tokens"
+    ],,
     "extensions": {
       "coingeckoId": "ftx-token"
     }


### PR DESCRIPTION
### Ticket:
- https://step-finance.atlassian.net/browse/SF-1093

### Notes:

Solend appears to have duplicate versions of their tokens

I notice 8 decimal places vs. 6 for their predefined `cFTT` and `cETH` tokens

Perhaps the portal token definitions are missing? These cTokens are based off of portal FTT and portal ETH which I only became aware of as I was fixing the lack of display of `cFTT` and `cETH`

They don't appear to use their own `token-list` repo: https://github.com/solendprotocol/token-list/branches so perhaps their front-end has the token details hard-coded? They display cTokens accurately on their own page.