### PR TITLE
fix UXP logo url

### DIFF
--- a/src/token-list.json
+++ b/src/token-list.json
@@ -801,7 +801,7 @@
     "symbol": "UXP",
     "name": "UXP Governance Token",
     "decimals": 9,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/UXPhBoR3qG4UCiGNJfV7MqhHyFqKN68g45GoYvAeL2M/logo.png",
+    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/UXPhBoR3qG4UCiGNJfV7MqhHyFqKN68g45GoYvAeL2M/uxp-icon-black.png",
     "tags": ["UXD", "UXP", "governance", "DAO", "stablecoin"],
     "extensions": {
       "coingeckoId": "uxd-protocol-token"


### PR DESCRIPTION
Update to match solana token list. Old logo link is dead.